### PR TITLE
Add React 19.2 view transitions

### DIFF
--- a/app/appearances/[slug]/page.tsx
+++ b/app/appearances/[slug]/page.tsx
@@ -38,6 +38,7 @@ export default async function AppearancePage(
       <Page.Header
         lead={<EventLead location={event.location} url={event.url} />}
         meta={<EventDate endDate={event.endDate} startDate={event.startDate} />}
+        viewTransitionName={`appearance-${params.slug}`}
       >
         {event.name} {event.startDate.getFullYear()}
       </Page.Header>

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -71,6 +71,7 @@ const PostPage = async (props: PageProps<'/posts/[slug]'>) => {
       <Article.Header
         lead={post.frontmatter.lead}
         meta={<DateDisplay value={post.frontmatter.publishedAt} />}
+        viewTransitionName={`post-${params.slug}`}
       >
         {post.frontmatter.title}
       </Article.Header>

--- a/app/talks/[slug]/page.tsx
+++ b/app/talks/[slug]/page.tsx
@@ -37,7 +37,11 @@ const TalkPage = async (props: PageProps<'/talks/[slug]'>) => {
 
   return (
     <Page>
-      <Page.Header lead={<TagCloud tags={talk.tags} />} meta="Talk">
+      <Page.Header
+        lead={<TagCloud tags={talk.tags} />}
+        meta="Talk"
+        viewTransitionName={`talk-${params.slug}`}
+      >
         {talk.title}
       </Page.Header>
       <Page.Body>

--- a/components/appearances/appearances-feed.tsx
+++ b/components/appearances/appearances-feed.tsx
@@ -30,6 +30,7 @@ export function AppearancesFeed({ children, events }: AppearancesFeedProps) {
               key={event.slug}
               link={`/appearances/${event.slug}`}
               title={event.name}
+              viewTransitionName={`appearance-${event.slug}`}
             />
           ))}
         </Feed>
@@ -43,6 +44,7 @@ export function AppearancesFeed({ children, events }: AppearancesFeedProps) {
               key={event.slug}
               link={`/appearances/${event.slug}`}
               title={event.name}
+              viewTransitionName={`appearance-${event.slug}`}
             />
           ))}
         </Feed>

--- a/components/avatar/avatar.tsx
+++ b/components/avatar/avatar.tsx
@@ -5,6 +5,7 @@ import type { ComponentPropsWithoutRef } from 'react';
 
 import { cva } from 'class-variance-authority';
 import Image from 'next/image';
+import { unstable_ViewTransition as ViewTransition } from 'react';
 
 import photo from '@/assets/images/photo.jpg';
 import { name } from '@/lib/constants';
@@ -40,16 +41,18 @@ export function Avatar({ size, className, ...props }: AvatarProps) {
   const imageSize = avatarImageSizes[size ?? 34];
 
   return (
-    <div className={classes}>
-      <div className="absolute inset-0 rounded-full bg-gradient-to-r from-transparent via-slate-200 to-transparent motion-safe:animate-spin motion-safe:[animation-duration:10s] dark:from-transparent dark:via-slate-800/50 dark:to-transparent" />
-      <Image
-        alt={name}
-        className="relative rounded-full"
-        placeholder="blur"
-        src={photo}
-        {...imageSize}
-        {...props}
-      />
-    </div>
+    <ViewTransition name="avatar">
+      <div className={classes}>
+        <div className="absolute inset-0 rounded-full bg-gradient-to-r from-transparent via-slate-200 to-transparent motion-safe:animate-spin motion-safe:[animation-duration:10s] dark:from-transparent dark:via-slate-800/50 dark:to-transparent" />
+        <Image
+          alt={name}
+          className="relative rounded-full"
+          placeholder="blur"
+          src={photo}
+          {...imageSize}
+          {...props}
+        />
+      </div>
+    </ViewTransition>
   );
 }

--- a/components/home/hero-avatar.tsx
+++ b/components/home/hero-avatar.tsx
@@ -2,26 +2,16 @@
 
 import type { ComponentPropsWithoutRef } from 'react';
 
-import { motion } from 'framer-motion';
-
 import { useIntersection } from '@/lib/hooks/use-intersection';
 
 type HeroAvatarProps = Omit<ComponentPropsWithoutRef<'div'>, 'className'>;
 
 export function HeroAvatar({ children }: HeroAvatarProps) {
-  const { isInView, ref } = useIntersection();
+  const { ref } = useIntersection();
 
   return (
     <div className="h-34 w-34" ref={ref}>
-      <motion.div
-        animate={
-          isInView ? { opacity: 1, scale: 1 } : { opacity: 0, scale: 0.95 }
-        }
-        initial={{ opacity: 0, scale: 0.95 }}
-        transition={{ type: 'spring', stiffness: 200, damping: 25 }}
-      >
-        {children}
-      </motion.div>
+      {children}
     </div>
   );
 }

--- a/components/home/posts.tsx
+++ b/components/home/posts.tsx
@@ -21,6 +21,7 @@ export const Posts = async () => {
               key={slug}
               link={`/posts/${slug}`}
               title={frontmatter.title}
+              viewTransitionName={`post-${slug}`}
             />
           ))}
         </Feed>

--- a/components/navigation/navbar-avatar.tsx
+++ b/components/navigation/navbar-avatar.tsx
@@ -2,7 +2,6 @@
 
 import type { ComponentPropsWithoutRef } from 'react';
 
-import { AnimatePresence, motion } from 'framer-motion';
 import { useContext } from 'react';
 
 import { useIsActivePathname } from '@/lib/hooks/use-is-active-pathname';
@@ -19,19 +18,5 @@ export function NavbarAvatar({ children }: NavbarAvatarProps) {
     return <>{children}</>;
   }
 
-  return (
-    <AnimatePresence>
-      {!isInView && (
-        <motion.div
-          animate={{ opacity: 1, scale: 1, y: 0 }}
-          className="flex flex-none"
-          exit={{ opacity: 0, scale: 0.95, y: '25%' }}
-          initial={{ opacity: 0, scale: 0.95, y: '25%' }}
-          transition={{ type: 'spring', stiffness: 200, damping: 25 }}
-        >
-          {children}
-        </motion.div>
-      )}
-    </AnimatePresence>
-  );
+  return !isInView ? <div className="flex flex-none">{children}</div> : null;
 }

--- a/components/talks/talks-feed.tsx
+++ b/components/talks/talks-feed.tsx
@@ -31,6 +31,7 @@ export function TalksFeed({ children, talks }: TalksFeedProps) {
               key={slug}
               link={`/talks/${slug}`}
               title={title}
+              viewTransitionName={`talk-${slug}`}
             />
           ))}
         </Feed>
@@ -48,6 +49,7 @@ export function TalksFeed({ children, talks }: TalksFeedProps) {
               key={slug}
               link={`/talks/${slug}`}
               title={title}
+              viewTransitionName={`talk-${slug}`}
             />
           ))}
         </Feed>

--- a/components/ui/layout/article.tsx
+++ b/components/ui/layout/article.tsx
@@ -1,5 +1,7 @@
 import type { ComponentPropsWithoutRef, ReactNode } from 'react';
 
+import { unstable_ViewTransition as ViewTransition } from 'react';
+
 import { Divider } from '../elements/divider';
 import { H1 } from '../typography/h1';
 import { Lead } from '../typography/lead';
@@ -34,13 +36,26 @@ interface ArticleHeaderProps
   extends Omit<ComponentPropsWithoutRef<'header'>, 'className' | 'title'> {
   lead?: ReactNode;
   meta: ReactNode;
+  viewTransitionName?: string;
 }
 
-function ArticleHeader({ children, lead, meta, ...props }: ArticleHeaderProps) {
+function ArticleHeader({
+  children,
+  lead,
+  meta,
+  viewTransitionName,
+  ...props
+}: ArticleHeaderProps) {
   return (
     <header className="mx-auto grid max-w-[70ch] gap-4" {...props}>
       {meta !== null && meta !== undefined && <Meta>{meta}</Meta>}
-      <H1>{children}</H1>
+      <H1>
+        {viewTransitionName ? (
+          <ViewTransition name={viewTransitionName}>{children}</ViewTransition>
+        ) : (
+          children
+        )}
+      </H1>
       {lead !== null && lead !== undefined && <Lead>{lead}</Lead>}
     </header>
   );

--- a/components/ui/layout/feed.tsx
+++ b/components/ui/layout/feed.tsx
@@ -1,6 +1,7 @@
 import type { ComponentPropsWithoutRef, ReactNode } from 'react';
 
 import { ChevronRight } from 'lucide-react';
+import { unstable_ViewTransition as ViewTransition } from 'react';
 
 import { cn } from '@/lib/utils';
 
@@ -61,6 +62,7 @@ interface FeedItemProps
   link?: string;
   meta?: ReactNode;
   title: string;
+  viewTransitionName?: string;
 }
 
 function FeedItem({
@@ -69,6 +71,7 @@ function FeedItem({
   description,
   link,
   title,
+  viewTransitionName,
   ...rest
 }: FeedItemProps) {
   const { date, meta, ...props } = {
@@ -87,17 +90,24 @@ function FeedItem({
     link && 'relative z-10',
     date !== undefined && 'text-slate-400 dark:text-slate-500',
   );
+  const titleContent = link ? (
+    <Link href={link}>
+      <span className="absolute -inset-4 z-20 md:-inset-6" />
+      <span className="relative z-10">{title}</span>
+    </Link>
+  ) : (
+    title
+  );
   const content = (
     <>
       <div className="grid">
         <H3>
-          {link ? (
-            <Link href={link}>
-              <span className="absolute -inset-4 z-20 md:-inset-6" />
-              <span className="relative z-10">{title}</span>
-            </Link>
+          {viewTransitionName ? (
+            <ViewTransition name={viewTransitionName}>
+              {titleContent}
+            </ViewTransition>
           ) : (
-            title
+            titleContent
           )}
         </H3>
         {meta === undefined ? (

--- a/components/ui/layout/page.tsx
+++ b/components/ui/layout/page.tsx
@@ -1,5 +1,7 @@
 import type { ComponentPropsWithoutRef, ReactNode } from 'react';
 
+import { unstable_ViewTransition as ViewTransition } from 'react';
+
 import { H1 } from '../typography/h1';
 import { Lead } from '../typography/lead';
 import { Meta } from '../typography/meta';
@@ -15,13 +17,26 @@ interface PageHeaderProps
   extends Omit<ComponentPropsWithoutRef<'header'>, 'className' | 'title'> {
   lead?: ReactNode;
   meta?: ReactNode;
+  viewTransitionName?: string;
 }
 
-function PageHeader({ children, lead, meta, ...props }: PageHeaderProps) {
+function PageHeader({
+  children,
+  lead,
+  meta,
+  viewTransitionName,
+  ...props
+}: PageHeaderProps) {
   return (
     <header className="grid max-w-4xl gap-4" {...props}>
       {meta !== null && meta !== undefined && <Meta>{meta}</Meta>}
-      <H1>{children}</H1>
+      <H1>
+        {viewTransitionName ? (
+          <ViewTransition name={viewTransitionName}>{children}</ViewTransition>
+        ) : (
+          children
+        )}
+      </H1>
       {lead !== null &&
         lead !== undefined &&
         (typeof lead === 'string' ? <Lead>{lead}</Lead> : lead)}

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,7 @@ const nextConfig: NextConfig = {
     reactCompiler: {
       compilationMode: 'annotation', // Opt-in mode - only compile files with 'use memo' directive
     },
+    viewTransition: true,
   },
   // Include content files in the build output for Vercel deployment
   outputFileTracingIncludes: {


### PR DESCRIPTION
## Summary
- Enable React 19.2's experimental View Transitions API
- Replace Framer Motion animations with native view transitions for the avatar
- Add smooth title transitions for posts, talks, and appearances

## Implementation Details

### Avatar Transitions
The avatar now smoothly morphs between the hero section and navbar using the shared element transition API with the name `"avatar"`. This replaces the previous Framer Motion-based fade/scale animations.

### Title Transitions
Post, talk, and appearance titles now transition smoothly when navigating from list pages to detail pages. Each uses a slug-based naming pattern:
- Posts: `post-${slug}`
- Talks: `talk-${slug}`
- Appearances: `appearance-${slug}`

### Browser Support
View Transitions gracefully degrade on unsupported browsers, showing instant content switches instead of animations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)